### PR TITLE
feat(api): add GET /tasks/count endpoint and tests

### DIFF
--- a/src/handlers/task_handler.rs
+++ b/src/handlers/task_handler.rs
@@ -95,4 +95,11 @@ pub async fn delete_task(
     }
 }
 
+/// Count tasks: GET /tasks/count
+pub async fn count_tasks(State(repo): State<AppState>) -> Json<serde_json::Value> {
+    log_info("count_tasks called");
+    let n = repo.count();
+    Json(json!({"count": n}))
+}
+
 // unit tests moved to `tests/handler_tests.rs` as integration tests

--- a/src/models/repository.rs
+++ b/src/models/repository.rs
@@ -49,6 +49,12 @@ impl TaskRepository {
         let mut m = self.inner.write();
         m.remove(id).is_some()
     }
+
+    /// Return the number of tasks currently stored.
+    pub fn count(&self) -> usize {
+        let m = self.inner.read();
+        m.len()
+    }
 }
 
 impl Default for TaskRepository {

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -8,13 +8,16 @@ use axum::{
 
 pub mod tasks;
 
-use crate::handlers::task_handler::{create_task, delete_task, get_task, get_tasks, update_task};
+use crate::handlers::task_handler::{
+    count_tasks, create_task, delete_task, get_task, get_tasks, update_task,
+};
 use crate::models::repository::TaskRepository;
 
 pub fn create_router() -> Router<TaskRepository> {
     let repo = TaskRepository::new();
     Router::new()
         .route("/tasks", post(create_task).get(get_tasks))
+        .route("/tasks/count", get(count_tasks))
         .route(
             "/tasks/{id}",
             get(get_task).put(update_task).delete(delete_task),

--- a/tests/handler_tests_count.rs
+++ b/tests/handler_tests_count.rs
@@ -1,0 +1,49 @@
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use rust_api_hub::handlers::task_handler::{count_tasks, create_task};
+use rust_api_hub::models::repository::TaskRepository;
+use rust_api_hub::models::task::TaskCreate;
+
+fn app_state() -> TaskRepository {
+    TaskRepository::new()
+}
+
+#[tokio::test]
+async fn count_empty_repo_is_zero() {
+    let repo = app_state();
+    let body = count_tasks(State(repo)).await;
+    // body is Json<Value> -> {"count": 0}
+    let v = body.0;
+    assert_eq!(v["count"].as_u64().unwrap(), 0);
+}
+
+#[tokio::test]
+async fn count_after_one_insert_is_one() {
+    let repo = app_state();
+    let payload = TaskCreate {
+        title: "t1".into(),
+        description: "d1".into(),
+    };
+    let (code, _created) = create_task(State(repo.clone()), Json(payload)).await;
+    assert_eq!(code, StatusCode::CREATED);
+    let body = count_tasks(State(repo)).await;
+    let v = body.0;
+    assert_eq!(v["count"].as_u64().unwrap(), 1);
+}
+
+#[tokio::test]
+async fn count_after_multiple_inserts_is_n() {
+    let repo = app_state();
+    for i in 0..5 {
+        let payload = TaskCreate {
+            title: format!("t{}", i),
+            description: "d".into(),
+        };
+        let (code, _created) = create_task(State(repo.clone()), Json(payload)).await;
+        assert_eq!(code, StatusCode::CREATED);
+    }
+    let body = count_tasks(State(repo)).await;
+    let v = body.0;
+    assert_eq!(v["count"].as_u64().unwrap(), 5);
+}


### PR DESCRIPTION
- Add TaskRepository::count() to return current task count.
- Add handler `count_tasks` exposing GET /tasks/count which returns {"count": N}.
- Wire route in `src/routes/mod.rs`: GET /tasks/count -> count_tasks.
- Add integration tests `tests/handler_tests_count.rs`:
  - count_empty_repo_is_zero
  - count_after_one_insert_is_one
  - count_after_multiple_inserts_is_n

Closes #2 