### PR TITLE
feat(tasks): add bulk DELETE /tasks endpoint and tests

### DIFF
--- a/src/models/repository.rs
+++ b/src/models/repository.rs
@@ -55,6 +55,18 @@ impl TaskRepository {
         let m = self.inner.read();
         m.len()
     }
+
+    /// Remove multiple tasks by id. Returns the number of tasks removed.
+    pub fn remove_many(&self, ids: &[Uuid]) -> usize {
+        let mut m = self.inner.write();
+        let mut removed = 0usize;
+        for id in ids {
+            if m.remove(id).is_some() {
+                removed += 1;
+            }
+        }
+        removed
+    }
 }
 
 impl Default for TaskRepository {

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -9,14 +9,17 @@ use axum::{
 pub mod tasks;
 
 use crate::handlers::task_handler::{
-    count_tasks, create_task, delete_task, get_task, get_tasks, update_task,
+    bulk_delete_tasks, count_tasks, create_task, delete_task, get_task, get_tasks, update_task,
 };
 use crate::models::repository::TaskRepository;
 
 pub fn create_router() -> Router<TaskRepository> {
     let repo = TaskRepository::new();
     Router::new()
-        .route("/tasks", post(create_task).get(get_tasks))
+        .route(
+            "/tasks",
+            post(create_task).get(get_tasks).delete(bulk_delete_tasks),
+        )
         .route("/tasks/count", get(count_tasks))
         .route(
             "/tasks/{id}",

--- a/tests/bulk_delete_tests.rs
+++ b/tests/bulk_delete_tests.rs
@@ -1,0 +1,66 @@
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use rust_api_hub::handlers::task_handler::{bulk_delete_tasks, create_task};
+use rust_api_hub::models::repository::TaskRepository;
+use rust_api_hub::models::task::TaskCreate;
+
+fn app_state() -> TaskRepository {
+    TaskRepository::new()
+}
+
+#[tokio::test]
+async fn bulk_delete_none_returns_zero() {
+    let repo = app_state();
+    let (code, body) = bulk_delete_tasks(State(repo.clone()), Json(Vec::<String>::new())).await;
+    assert_eq!(code, StatusCode::OK);
+    let v = body.0;
+    assert_eq!(v["deleted"].as_u64().unwrap(), 0);
+}
+
+#[tokio::test]
+async fn bulk_delete_some_removes_only_specified() {
+    let repo = app_state();
+    // create 3 tasks
+    let mut ids = Vec::new();
+    for i in 0..3 {
+        let payload = TaskCreate {
+            title: format!("t{}", i),
+            description: "d".into(),
+        };
+        let (code, created) = create_task(State(repo.clone()), Json(payload)).await;
+        assert_eq!(code, StatusCode::CREATED);
+        ids.push(created.id.to_string());
+    }
+
+    // delete first two
+    let delete_ids = vec![ids[0].clone(), ids[1].clone()];
+    let (code, body) = bulk_delete_tasks(State(repo.clone()), Json(delete_ids)).await;
+    assert_eq!(code, StatusCode::OK);
+    let v = body.0;
+    assert_eq!(v["deleted"].as_u64().unwrap(), 2);
+
+    // remaining should be 1
+    let remaining = repo.list();
+    assert_eq!(remaining.len(), 1);
+}
+
+#[tokio::test]
+async fn bulk_delete_all_removes_everything() {
+    let repo = app_state();
+    let mut ids = Vec::new();
+    for i in 0..5 {
+        let payload = TaskCreate {
+            title: format!("t{}", i),
+            description: "d".into(),
+        };
+        let (code, created) = create_task(State(repo.clone()), Json(payload)).await;
+        assert_eq!(code, StatusCode::CREATED);
+        ids.push(created.id.to_string());
+    }
+    let (code, body) = bulk_delete_tasks(State(repo.clone()), Json(ids)).await;
+    assert_eq!(code, StatusCode::OK);
+    let v = body.0;
+    assert_eq!(v["deleted"].as_u64().unwrap(), 5);
+    assert_eq!(repo.list().len(), 0);
+}


### PR DESCRIPTION
- Add `TaskRepository::remove_many(&[Uuid]) -> usize` for efficient bulk removal.
- Add handler `bulk_delete_tasks` in `src/handlers/task_handler.rs` which accepts a JSON array of UUID strings and returns `{"deleted": N}`.
- Wire `DELETE /tasks` in `src/routes/mod.rs`.
- Add integration tests in `tests/bulk_delete_tests.rs`:
  - `bulk_delete_none_returns_zero`
  - `bulk_delete_some_removes_only_specified`
  - `bulk_delete_all_removes_everything`

Closes #3 