### PR TITLE
feat(import): unified POST /tasks/import for CSV or JSON with partial-success

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,20 +64,21 @@ The `GET /tasks` response now returns a JSON object with metadata, for example:
 - `PUT /tasks/{id}` — update a task (partial fields allowed)
 - `DELETE /tasks/{id}` — delete a task
 
-- `POST /tasks/import` — import tasks from a JSON array. Request body: `[{"title":"...","description":"..."}, ...]`.
-	- Response: `201 Created` with body `{ "imported": N, "tasks": [ /* created tasks */ ] }`.
+- `POST /tasks/import` — import tasks in bulk. Accepts either:
+	- `application/json` — a JSON array of TaskCreate objects: `[{"title":"...","description":"..."}, ...]`.
+	- `text/csv` — CSV body with header row containing `title,description`.
+	- The endpoint validates rows (title must be non-empty), allows partial successes, and returns `201 Created` with a summary:
 
-- `POST /tasks/import/csv` — import tasks from CSV body. Expects a header row with `title,description`.
-	- Content-Type: `text/csv` (or send raw body). Example CSV:
-
+```json
+{
+	"imported": 3,
+	"failed": 1,
+	"errors": [{"index":0,"error":"..."}],
+	"tasks": [ /* created tasks */ ]
+}
 ```
-title,description
-task A,desc A
-task B,desc B
-```
 
-	- Response: `201 Created` with body `{ "imported": N, "tasks": [ /* created tasks */ ] }`.
-	- On parse errors or invalid UTF-8 the endpoint returns `400 Bad Request` with an error message.
+	- On invalid payload (unparseable JSON or invalid UTF-8 CSV) the endpoint returns `400 Bad Request`.
 
 Example curl (when server is running):
 

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -25,6 +25,17 @@ pub struct TaskCreate {
     pub description: String,
 }
 
+impl TaskCreate {
+    /// Basic validation for creation DTOs.
+    /// Returns Err with a short message if invalid.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.title.trim().is_empty() {
+            return Err("title must not be empty".into());
+        }
+        Ok(())
+    }
+}
+
 /// Input DTO for task updates
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TaskUpdate {

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -9,8 +9,8 @@ use axum::{
 pub mod tasks;
 
 use crate::handlers::task_handler::{
-    bulk_delete_tasks, count_tasks, create_task, delete_task, get_task, get_tasks,
-    import_tasks_csv, import_tasks_json, update_task,
+    bulk_delete_tasks, count_tasks, create_task, delete_task, get_task, get_tasks, import_tasks,
+    update_task,
 };
 use crate::models::repository::TaskRepository;
 
@@ -21,8 +21,7 @@ pub fn create_router() -> Router<TaskRepository> {
             "/tasks",
             post(create_task).get(get_tasks).delete(bulk_delete_tasks),
         )
-        .route("/tasks/import", post(import_tasks_json))
-        .route("/tasks/import/csv", post(import_tasks_csv))
+        .route("/tasks/import", post(import_tasks))
         .route("/tasks/count", get(count_tasks))
         .route(
             "/tasks/{id}",

--- a/tests/import_unified_tests.rs
+++ b/tests/import_unified_tests.rs
@@ -1,0 +1,91 @@
+use axum::Json;
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
+use rust_api_hub::models::repository::TaskRepository;
+use rust_api_hub::models::task::TaskCreate;
+
+fn app_state() -> TaskRepository {
+    TaskRepository::new()
+}
+
+#[tokio::test]
+async fn import_json_valid_inserts_all() {
+    let repo = app_state();
+    let payload = vec![
+        TaskCreate {
+            title: "A".into(),
+            description: "d1".into(),
+        },
+        TaskCreate {
+            title: "B".into(),
+            description: "d2".into(),
+        },
+    ];
+    let body = Bytes::from(serde_json::to_vec(&payload).unwrap());
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/json"),
+    );
+
+    let (code, Json(resp)) =
+        rust_api_hub::handlers::task_handler::import_tasks(State(repo.clone()), headers, body)
+            .await;
+    assert_eq!(code, StatusCode::CREATED);
+    assert_eq!(resp["imported"].as_u64().unwrap(), 2);
+    assert_eq!(repo.count(), 2);
+    assert!(resp["tasks"].as_array().unwrap().len() >= 2);
+}
+
+#[tokio::test]
+async fn import_json_partial_failure_reports_errors() {
+    let repo = app_state();
+    // second entry has empty title -> should be invalid (validation rule)
+    let payload = vec![
+        TaskCreate {
+            title: "Good".into(),
+            description: "d1".into(),
+        },
+        TaskCreate {
+            title: "".into(),
+            description: "d-bad".into(),
+        },
+    ];
+    let body = Bytes::from(serde_json::to_vec(&payload).unwrap());
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/json"),
+    );
+
+    let (code, Json(resp)) =
+        rust_api_hub::handlers::task_handler::import_tasks(State(repo.clone()), headers, body)
+            .await;
+    assert_eq!(code, StatusCode::CREATED);
+    assert_eq!(resp["imported"].as_u64().unwrap(), 1);
+    assert_eq!(resp["failed"].as_u64().unwrap(), 1);
+    let errors = resp["errors"].as_array().unwrap();
+    assert!(!errors.is_empty());
+    assert_eq!(repo.count(), 1);
+}
+
+#[tokio::test]
+async fn import_csv_partial_rows_are_reported() {
+    let repo = app_state();
+    // CSV: header + one valid row + one row missing title
+    let csv = "title,description\nOkay,desc1\n,missing-title\n";
+    let body = Bytes::from(csv);
+    let mut headers = HeaderMap::new();
+    headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("text/csv"));
+
+    let (code, Json(resp)) =
+        rust_api_hub::handlers::task_handler::import_tasks(State(repo.clone()), headers, body)
+            .await;
+    assert_eq!(code, StatusCode::CREATED);
+    assert_eq!(resp["imported"].as_u64().unwrap(), 1);
+    assert_eq!(resp["failed"].as_u64().unwrap(), 1);
+    assert_eq!(repo.count(), 1);
+    let errors = resp["errors"].as_array().unwrap();
+    assert!(errors.iter().any(|e| e["error"].as_str().is_some()));
+}


### PR DESCRIPTION

Add a single bulk-import endpoint that accepts either a JSON array of `TaskCreate` objects or a CSV body (header: title,description). The handler validates each row (title must be non-empty), persists valid rows via `insert_many`, and returns a summary allowing partial success:

- Adds `TaskCreate::validate()` in `src/models/task.rs`
- Adds unified handler `import_tasks` in `src/handlers/task_handler.rs`
- Routes `POST /tasks/import` in `src/routes/mod.rs`
- Adds integration tests `tests/import_unified_tests.rs`
- Updates README with API and response shape

Returns 201 with `{ imported, failed, errors, tasks }` on success; 400 on bad payload.

Closes #11 