### PR TITLE
feat(import): add multipart CSV file upload endpoint (POST /tasks/import/file)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ The `GET /tasks` response now returns a JSON object with metadata, for example:
 
 	- On invalid payload (unparseable JSON or invalid UTF-8 CSV) the endpoint returns `400 Bad Request`.
 
+	- `POST /tasks/import/file` — upload a CSV file using multipart/form-data (field name `file`).
+		- Useful for browser-based or file-upload clients.
+		- The server enforces a maximum upload size (5 MB by default) and returns `413 Payload Too Large` if exceeded.
+		- The response mirrors the unified import format and reports partial successes: `{ imported, failed, errors, tasks }`.
+
 Example curl (when server is running):
 
 ```powershell

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -10,7 +10,7 @@ pub mod tasks;
 
 use crate::handlers::task_handler::{
     bulk_delete_tasks, count_tasks, create_task, delete_task, get_task, get_tasks, import_tasks,
-    update_task,
+    import_tasks_file, update_task,
 };
 use crate::models::repository::TaskRepository;
 
@@ -22,6 +22,7 @@ pub fn create_router() -> Router<TaskRepository> {
             post(create_task).get(get_tasks).delete(bulk_delete_tasks),
         )
         .route("/tasks/import", post(import_tasks))
+        .route("/tasks/import/file", post(import_tasks_file))
         .route("/tasks/count", get(count_tasks))
         .route(
             "/tasks/{id}",

--- a/tests/import_file_tests.rs
+++ b/tests/import_file_tests.rs
@@ -1,0 +1,106 @@
+use axum::Json;
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
+use rust_api_hub::models::repository::TaskRepository;
+
+fn app_state() -> TaskRepository {
+    TaskRepository::new()
+}
+
+#[tokio::test]
+async fn file_import_valid_csv_inserts_all() {
+    let repo = app_state();
+    // build a simple multipart body with boundary 'BOUND'
+    let boundary = "BOUND";
+    let csv = "title,description\nOne,desc1\nTwo,desc2\n";
+    let mut body = String::new();
+    body.push_str(&format!("--{}\r\n", boundary));
+    body.push_str("Content-Disposition: form-data; name=\"file\"; filename=\"tasks.csv\"\r\n");
+    body.push_str("Content-Type: text/csv\r\n\r\n");
+    body.push_str(csv);
+    body.push_str(&format!("\r\n--{}--\r\n", boundary));
+
+    let bytes = Bytes::from(body);
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_str(&format!("multipart/form-data; boundary={}", boundary)).unwrap(),
+    );
+
+    let (code, Json(resp)) = rust_api_hub::handlers::task_handler::import_tasks_file(
+        State(repo.clone()),
+        headers,
+        bytes,
+    )
+    .await;
+    assert_eq!(code, StatusCode::CREATED);
+    assert_eq!(resp["imported"].as_u64().unwrap(), 2);
+    assert_eq!(repo.count(), 2);
+}
+
+#[tokio::test]
+async fn file_import_partial_failure_reports_rows() {
+    let repo = app_state();
+    let boundary = "BOUND";
+    let csv = "title,description\nGood,ok\n,missing-title\n";
+    let mut body = String::new();
+    body.push_str(&format!("--{}\r\n", boundary));
+    body.push_str("Content-Disposition: form-data; name=\"file\"; filename=\"tasks.csv\"\r\n");
+    body.push_str("Content-Type: text/csv\r\n\r\n");
+    body.push_str(csv);
+    body.push_str(&format!("\r\n--{}--\r\n", boundary));
+
+    let bytes = Bytes::from(body);
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_str(&format!("multipart/form-data; boundary={}", boundary)).unwrap(),
+    );
+
+    let (code, Json(resp)) = rust_api_hub::handlers::task_handler::import_tasks_file(
+        State(repo.clone()),
+        headers,
+        bytes,
+    )
+    .await;
+    assert_eq!(code, StatusCode::CREATED);
+    assert_eq!(resp["imported"].as_u64().unwrap(), 1);
+    assert_eq!(resp["failed"].as_u64().unwrap(), 1);
+    assert_eq!(repo.count(), 1);
+    let errors = resp["errors"].as_array().unwrap();
+    assert!(errors.iter().any(|e| e["row"].as_u64().is_some()));
+}
+
+#[tokio::test]
+async fn file_import_too_large_returns_413() {
+    let repo = app_state();
+    let boundary = "BOUND";
+    // create a csv large enough to exceed the 5 MB limit by repeating a line
+    let mut csv = String::from("title,description\n");
+    // build a large csv by repeating a long description to exceed 5MB
+    for _ in 0..6000 {
+        csv.push_str(&format!("tline,{}\n", "x".repeat(1000)));
+    }
+    let mut body = String::new();
+    body.push_str(&format!("--{}\r\n", boundary));
+    body.push_str("Content-Disposition: form-data; name=\"file\"; filename=\"tasks.csv\"\r\n");
+    body.push_str("Content-Type: text/csv\r\n\r\n");
+    body.push_str(&csv);
+    body.push_str(&format!("\r\n--{}--\r\n", boundary));
+
+    let bytes = Bytes::from(body);
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_str(&format!("multipart/form-data; boundary={}", boundary)).unwrap(),
+    );
+
+    let (code, _resp) = rust_api_hub::handlers::task_handler::import_tasks_file(
+        State(repo.clone()),
+        headers,
+        bytes,
+    )
+    .await;
+    assert_eq!(code, StatusCode::PAYLOAD_TOO_LARGE);
+}


### PR DESCRIPTION
Add support for uploading a CSV file via multipart/form-data to import tasks in bulk.

- Adds `import_tasks_file` handler to `src/handlers/task_handler.rs`
- Wires `POST /tasks/import/file` in `src/routes/mod.rs`
- Enforces a 5 MB upload size limit (returns 413 Payload Too Large)
- Parses uploaded CSV (header: title,description), validates rows (title non-empty), persists valid rows via `insert_many`, and returns a partial-success summary: `{ imported, failed, errors, tasks }`
- Adds integration tests in `tests/import_file_tests.rs` (valid, partial failure, too-large)
- Updates `README.md` with endpoint docs and usage notes

Notes: this implementation uses a lightweight boundary-splitting parser for multipart parts. Consider replacing with a streaming multipart parser (e.g. multer / axum-extra) in a follow-up PR.

Closes #13 