### PR TITLE
feat: add task priority system with filtering and sorting

### DIFF
--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -6,6 +6,43 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use uuid::Uuid;
 
+/// Task priority levels for prioritization and sorting.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Priority {
+    Low,
+    #[default]
+    Medium,
+    High,
+    Critical,
+}
+
+impl Priority {
+    /// Parse a priority from string (case-insensitive).
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s.trim().to_lowercase().as_str() {
+            "low" => Ok(Priority::Low),
+            "medium" => Ok(Priority::Medium),
+            "high" => Ok(Priority::High),
+            "critical" => Ok(Priority::Critical),
+            _ => Err(format!(
+                "invalid priority: '{}'. Valid values: low, medium, high, critical",
+                s
+            )),
+        }
+    }
+
+    /// Numeric value for sorting (higher number = higher priority).
+    pub fn sort_value(&self) -> u8 {
+        match self {
+            Priority::Low => 1,
+            Priority::Medium => 2,
+            Priority::High => 3,
+            Priority::Critical => 4,
+        }
+    }
+}
+
 /// The domain Task object stored in memory.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Task {
@@ -19,6 +56,9 @@ pub struct Task {
     /// Optional labels for grouping and filtering.
     #[serde(default)]
     pub tags: Vec<String>,
+    /// Task priority level.
+    #[serde(default)]
+    pub priority: Priority,
 }
 
 /// Input DTO for task creation
@@ -59,6 +99,7 @@ impl Task {
             created_at: now,
             updated_at: now,
             tags: Vec::new(),
+            priority: Priority::default(),
         }
     }
 
@@ -88,6 +129,7 @@ impl Task {
             "created_at": self.created_at.to_rfc3339(),
             "updated_at": self.updated_at.to_rfc3339(),
             "tags": self.tags,
+            "priority": self.priority,
         })
     }
 }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -9,8 +9,9 @@ use axum::{
 pub mod tasks;
 
 use crate::handlers::task_handler::{
-    bulk_delete_tasks, count_tasks, create_task, delete_task, get_stats, get_tags, get_task,
-    get_tasks, get_tasks_by_tag, import_tasks, import_tasks_file, set_tags, update_task,
+    bulk_delete_tasks, count_tasks, create_task, delete_task, get_priority, get_stats, get_tags,
+    get_task, get_tasks, get_tasks_by_priority, get_tasks_by_tag, import_tasks, import_tasks_file,
+    set_priority, set_tags, update_task,
 };
 use crate::models::repository::TaskRepository;
 
@@ -26,11 +27,13 @@ pub fn create_router() -> Router<TaskRepository> {
         .route("/tasks/count", get(count_tasks))
         .route("/tasks/stats", get(get_stats))
         .route("/tasks/search/by_tag", get(get_tasks_by_tag))
+        .route("/tasks/search/by_priority", get(get_tasks_by_priority))
         .route(
             "/tasks/{id}",
             get(get_task).put(update_task).delete(delete_task),
         )
         .route("/tasks/{id}/tags", get(get_tags).put(set_tags))
+        .route("/tasks/{id}/priority", get(get_priority).put(set_priority))
         .route("/health", get(tasks::health))
         .route("/info", get(tasks::info))
         .with_state(repo)

--- a/tests/priority_tests.rs
+++ b/tests/priority_tests.rs
@@ -1,0 +1,187 @@
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use rust_api_hub::handlers::task_handler::PriorityPayload;
+use rust_api_hub::models::repository::TaskRepository;
+use rust_api_hub::models::task::TaskCreate;
+
+fn repo() -> TaskRepository {
+    TaskRepository::new()
+}
+
+#[tokio::test]
+async fn set_and_get_priority_roundtrip() {
+    let repo = repo();
+
+    // create a task
+    let payload = TaskCreate {
+        title: "test task".into(),
+        description: "desc".into(),
+    };
+    let (_code, Json(task)) =
+        rust_api_hub::handlers::task_handler::create_task(State(repo.clone()), Json(payload)).await;
+
+    // default priority should be medium
+    assert_eq!(task.priority, rust_api_hub::models::task::Priority::Medium);
+
+    // set priority to high
+    let priority_payload = PriorityPayload {
+        priority: "high".into(),
+    };
+    let result = rust_api_hub::handlers::task_handler::set_priority(
+        Path(task.id.to_string()),
+        State(repo.clone()),
+        Json(priority_payload),
+    )
+    .await;
+    assert!(result.is_ok());
+
+    // get priority and verify
+    let result = rust_api_hub::handlers::task_handler::get_priority(
+        Path(task.id.to_string()),
+        State(repo.clone()),
+    )
+    .await;
+    assert!(result.is_ok());
+    let Json(resp) = result.unwrap();
+    assert_eq!(resp["priority"].as_str().unwrap(), "high");
+}
+
+#[tokio::test]
+async fn search_by_priority_filters_correctly() {
+    let repo = repo();
+
+    // create 5 tasks with different priorities
+    let priorities = vec!["low", "medium", "high", "critical", "medium"];
+
+    for (i, prio) in priorities.iter().enumerate() {
+        let payload = TaskCreate {
+            title: format!("task{}", i),
+            description: "d".into(),
+        };
+        let (_code, Json(task)) =
+            rust_api_hub::handlers::task_handler::create_task(State(repo.clone()), Json(payload))
+                .await;
+
+        // set priority
+        let priority_payload = PriorityPayload {
+            priority: prio.to_string(),
+        };
+        let _ = rust_api_hub::handlers::task_handler::set_priority(
+            Path(task.id.to_string()),
+            State(repo.clone()),
+            Json(priority_payload),
+        )
+        .await;
+    }
+
+    // search for medium priority tasks (should be 2)
+    let mut params = std::collections::HashMap::new();
+    params.insert("priority".to_string(), "medium".to_string());
+
+    let result = rust_api_hub::handlers::task_handler::get_tasks_by_priority(
+        State(repo.clone()),
+        Query(params),
+    )
+    .await;
+    assert!(result.is_ok());
+    let Json(tasks) = result.unwrap();
+    assert_eq!(tasks.len(), 2);
+    for task in tasks {
+        assert_eq!(task.priority, rust_api_hub::models::task::Priority::Medium);
+    }
+}
+
+#[tokio::test]
+async fn invalid_priority_rejected() {
+    let repo = repo();
+
+    // create a task
+    let payload = TaskCreate {
+        title: "test".into(),
+        description: "d".into(),
+    };
+    let (_code, Json(task)) =
+        rust_api_hub::handlers::task_handler::create_task(State(repo.clone()), Json(payload)).await;
+
+    // try to set invalid priority
+    let priority_payload = PriorityPayload {
+        priority: "invalid".into(),
+    };
+    let result = rust_api_hub::handlers::task_handler::set_priority(
+        Path(task.id.to_string()),
+        State(repo.clone()),
+        Json(priority_payload),
+    )
+    .await;
+
+    assert!(result.is_err());
+    let (status, msg) = result.unwrap_err();
+    assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+    assert!(msg.contains("invalid priority"));
+}
+
+#[tokio::test]
+async fn sort_by_priority_orders_correctly() {
+    let repo = repo();
+
+    // create tasks with different priorities
+    let priorities = vec!["low", "critical", "medium", "high"];
+
+    for (i, prio) in priorities.iter().enumerate() {
+        let payload = TaskCreate {
+            title: format!("task{}", i),
+            description: "d".into(),
+        };
+        let (_code, Json(task)) =
+            rust_api_hub::handlers::task_handler::create_task(State(repo.clone()), Json(payload))
+                .await;
+
+        let priority_payload = PriorityPayload {
+            priority: prio.to_string(),
+        };
+        let _ = rust_api_hub::handlers::task_handler::set_priority(
+            Path(task.id.to_string()),
+            State(repo.clone()),
+            Json(priority_payload),
+        )
+        .await;
+    }
+
+    // get tasks sorted by priority ascending (low to critical)
+    let params = rust_api_hub::handlers::task_handler::ListParams {
+        completed: None,
+        page: None,
+        per_page: None,
+        sort: Some("priority:asc".into()),
+    };
+
+    let Json(resp) =
+        rust_api_hub::handlers::task_handler::get_tasks(State(repo.clone()), Query(params)).await;
+
+    let items = resp["items"].as_array().unwrap();
+    assert_eq!(items.len(), 4);
+
+    // verify order: low, medium, high, critical
+    assert_eq!(items[0]["priority"].as_str().unwrap(), "low");
+    assert_eq!(items[1]["priority"].as_str().unwrap(), "medium");
+    assert_eq!(items[2]["priority"].as_str().unwrap(), "high");
+    assert_eq!(items[3]["priority"].as_str().unwrap(), "critical");
+
+    // test descending order
+    let params_desc = rust_api_hub::handlers::task_handler::ListParams {
+        completed: None,
+        page: None,
+        per_page: None,
+        sort: Some("priority:desc".into()),
+    };
+
+    let Json(resp_desc) =
+        rust_api_hub::handlers::task_handler::get_tasks(State(repo.clone()), Query(params_desc))
+            .await;
+
+    let items_desc = resp_desc["items"].as_array().unwrap();
+    assert_eq!(items_desc[0]["priority"].as_str().unwrap(), "critical");
+    assert_eq!(items_desc[1]["priority"].as_str().unwrap(), "high");
+    assert_eq!(items_desc[2]["priority"].as_str().unwrap(), "medium");
+    assert_eq!(items_desc[3]["priority"].as_str().unwrap(), "low");
+}


### PR DESCRIPTION
Add priority field to tasks with four levels (low, medium, high, critical):
- New Priority enum with serialization and default (medium)
- PUT /tasks/{id}/priority - set task priority
- GET /tasks/{id}/priority - get task priority
- GET /tasks/search/by_priority?priority=... - filter by priority
- Extended GET /tasks?sort=priority:asc|desc - sort by priority level
- Case-insensitive priority parsing with validation

Implementation includes:
- Priority enum with derive macros (Default, Serialize, etc.)
- Priority::parse() method for case-insensitive validation
- sort_value() method for numeric priority ordering
- 4 integration tests covering set/get, filtering, validation, and sorting
- README documentation with endpoints, validation rules, and examples
Closes #19 